### PR TITLE
Fix the URL to redirect to

### DIFF
--- a/src/loogle-api.ts
+++ b/src/loogle-api.ts
@@ -48,14 +48,14 @@ export interface HitDBInterface {
 
 
 export class LoogleHit {
-    quickPickItem : vscode.QuickPickItem;
+    quickPickItem : LoogleHitItem;
     moduleUri : string;
     moduleName : string;
     constructor(hitObject: HitObject) {
         let docUrl : string = "https://leanprover-community.github.io/mathlib4_docs/";
         this.quickPickItem = new LoogleHitItem(hitObject);
         this.moduleName = hitObject.module;
-        let modulePath = this.moduleName.replace(/\./g,'/').concat('.html').concat(`#${this.moduleName}`);
+        let modulePath = this.moduleName.replace(/\./g,'/').concat('.html').concat(`#${this.quickPickItem.label}`);
         this.moduleUri = encodeURI(docUrl.concat(modulePath));
     }
     projectQPI() {


### PR DESCRIPTION
The extension used to redirect to something like `docs/A/B/C#A.B.C`, when actually we wanted it to redirect to `docs/A/B/C#My.Decl.Name`. I quickly patch this to work, and am maybe considering a bigger refactor to make this all a bit more robust.
