### PR TITLE
swap where the module and the type show

### DIFF
--- a/src/loogle-api.ts
+++ b/src/loogle-api.ts
@@ -71,14 +71,15 @@ export class LoogleHitItem implements vscode.QuickPickItem {
 
     constructor(hitObject : HitObject) {
         this.label = hitObject.name;
-        this.description = ":: ".concat(hitObject.type);
+        const spaces : RegExp = /\s+/g;
+        this.detail = hitObject.type.replace(spaces, ' ');
         let shouldModule = vscode.workspace.getConfiguration().get("loogle-lean.showModuleName");
         console.log(shouldModule);
         if(shouldModule === true) {
-            this.detail = `Module : ${hitObject.module}`;//`${moduleName} $(link-external-16)`;//(${moduleUri})`);
+            this.description = `${hitObject.module}`;//`${moduleName} $(link-external-16)`;//(${moduleUri})`);
         }
         else {
-            this.detail = "   ";//`${moduleName} $(link-external-16)`;//(${moduleUri})`);
+            this.description = "   ";//`${moduleName} $(link-external-16)`;//(${moduleUri})`);
         }
 
         let buttonDocs = {


### PR DESCRIPTION
I made it so that the type and where the module are swap, e.g. see top for old behaviour bottom for new [waiting on Loogle to return for demo photos].

It'd be nice if we could make the quickpick items bigger instead so we can see the whole type, but at least now hovering shows the whole type.